### PR TITLE
conftest pullにHTTPSを利用する

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository manages the standard policies for security and governance checks
 $ cd terraform
 
 # Download the policy
-$ conftest pull 'git@github.com:sacloud/terraform-provider-sakuracloud-policy.git//policy?ref=v1.0.0'
+$ conftest pull 'git::https://github.com/sacloud/terraform-provider-sakuracloud-policy.git//policy?ref=v1.0.0'
 
 # Run the tests
 $ conftest test . --ignore=".git/|.github/|.terraform/"


### PR DESCRIPTION
## 概要
`conftest pull` コマンドでポリシーをダウンロードする際に、SSHキーによる認証が必要なくなるようにHTTPSを利用するように変更しました。

## 動作確認
なし