### PR TITLE
メッセージにドキュメントのURLを追加

### DIFF
--- a/policy/sakuracloud_disk.rego
+++ b/policy/sakuracloud_disk.rego
@@ -8,5 +8,9 @@ deny_sakuracloud_disk_not_encrypted[msg] {
 	disk := input.resource.sakuracloud_disk[name]
 	not disk.encryption_algorithm == "aes256_xts"
 
-	msg := sprintf("Disk encryption is not enabled in sakuracloud_disk.%s", [name])
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/"
+	msg := sprintf(
+		"Disk encryption is not enabled in sakuracloud_disk.%s\nMore Info: %s\n",
+		[name, url],
+	)
 }

--- a/policy/sakuracloud_disk_test.rego
+++ b/policy/sakuracloud_disk_test.rego
@@ -11,8 +11,7 @@ resource "sakuracloud_disk" "test" {
   connector            = "virtio"
   source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
 }`)
-
-	deny_sakuracloud_disk_not_encrypted["Disk encryption is not enabled in sakuracloud_disk.test"] with input as cfg
+	deny_sakuracloud_disk_not_encrypted["Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n"] with input as cfg
 }
 
 test_specified_encryption_algorithm_none {
@@ -25,8 +24,7 @@ resource "sakuracloud_disk" "test" {
   source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
   encryption_algorithm = "none"
 }`)
-
-	deny_sakuracloud_disk_not_encrypted["Disk encryption is not enabled in sakuracloud_disk.test"] with input as cfg
+	deny_sakuracloud_disk_not_encrypted["Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n"] with input as cfg
 }
 
 test_specified_encryption_algorithm_aes256_xts {
@@ -39,6 +37,5 @@ resource "sakuracloud_disk" "test" {
   source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
   encryption_algorithm = "aes256_xts"
 }`)
-
 	no_violations(deny_sakuracloud_disk_not_encrypted) with input as cfg
 }

--- a/policy/sakuracloud_enhanced_db.rego
+++ b/policy/sakuracloud_enhanced_db.rego
@@ -9,5 +9,9 @@ deny_sakuracloud_enhanced_db_unrestricted_source_networks[msg] {
 
 	not has_field(enhanced_db, "allowed_networks")
 
-	msg := sprintf("Source network is not restricted for sakuracloud_enhanced_db.%s connection", [name])
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/"
+	msg := sprintf(
+		"Source network is not restricted for sakuracloud_enhanced_db.%s connection\nMore Info: %s\n",
+		[name, url],
+	)
 }

--- a/policy/sakuracloud_enhanced_db_test.rego
+++ b/policy/sakuracloud_enhanced_db_test.rego
@@ -13,7 +13,7 @@ resource "sakuracloud_enhanced_db" "test" {
   region        = "is1"
 }`)
 
-	deny_sakuracloud_enhanced_db_unrestricted_source_networks["Source network is not restricted for sakuracloud_enhanced_db.test connection"] with input as cfg
+	deny_sakuracloud_enhanced_db_unrestricted_source_networks["Source network is not restricted for sakuracloud_enhanced_db.test connection\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/\n"] with input as cfg
 }
 
 test_specified_allowed_networks {

--- a/policy/sakuracloud_load_balancer.rego
+++ b/policy/sakuracloud_load_balancer.rego
@@ -8,5 +8,9 @@ deny_sakuracloud_load_balancer_http_not_enabled[msg] {
 	load_balancer := input.resource.sakuracloud_load_balancer[name]
 	load_balancer.vip.port == 80
 
-	msg := sprintf("Port 80 is open on the VIP address of sakuracloud_load_balancer.%s", [name])
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/"
+	msg := sprintf(
+		"Port 80 is open on the VIP address of sakuracloud_load_balancer.%s\nMore Info: %s\n",
+		[name, url],
+	)
 }

--- a/policy/sakuracloud_load_balancer_test.rego
+++ b/policy/sakuracloud_load_balancer_test.rego
@@ -34,7 +34,7 @@ resource "sakuracloud_load_balancer" "test" {
   }
 }`)
 
-	deny_sakuracloud_load_balancer_http_not_enabled["Port 80 is open on the VIP address of sakuracloud_load_balancer.test"] with input as cfg
+	deny_sakuracloud_load_balancer_http_not_enabled["Port 80 is open on the VIP address of sakuracloud_load_balancer.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/\n"] with input as cfg
 }
 
 test_enable_https_port {

--- a/policy/sakuracloud_proxylb.rego
+++ b/policy/sakuracloud_proxylb.rego
@@ -6,9 +6,13 @@ import data.helpers.has_field
 deny_sakuracloud_proxylb_no_https_redirect[msg] {
 	some name
 	proxylb := input.resource.sakuracloud_proxylb[name]
-
 	not redirect_https(proxylb)
-	msg := sprintf("HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.%s", [name])
+
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/"
+	msg := sprintf(
+		"HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.%s\nMore Info: %s\n",
+		[name, url],
+	)
 }
 
 redirect_https(proxylb) {
@@ -28,5 +32,9 @@ warn_sakuracloud_proxylb_unspecified_syslog_host[msg] {
 	proxylb := input.resource.sakuracloud_proxylb[name]
 	not has_field(proxylb, "syslog")
 
-	msg := sprintf("No syslog server is configured for sakuracloud_proxylb.%s", [name])
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/"
+	msg := sprintf(
+		"No syslog server is configured for sakuracloud_proxylb.%s\nMore Info: %s\n",
+		[name, url],
+	)
 }

--- a/policy/sakuracloud_proxylb_test.rego
+++ b/policy/sakuracloud_proxylb_test.rego
@@ -20,7 +20,7 @@ resource "sakuracloud_proxylb" "test" {
     port       = 80
   }
 }`)
-	deny_sakuracloud_proxylb_no_https_redirect["HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test"] with input as cfg
+	deny_sakuracloud_proxylb_no_https_redirect["HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n"] with input as cfg
 }
 
 test_disable_redirect_to_https {
@@ -42,7 +42,7 @@ resource "sakuracloud_proxylb" "test" {
     redirect_to_https = false
   }
 }`)
-	deny_sakuracloud_proxylb_no_https_redirect["HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test"] with input as cfg
+	deny_sakuracloud_proxylb_no_https_redirect["HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n"] with input as cfg
 }
 
 test_redirect_to_https {
@@ -109,7 +109,7 @@ resource "sakuracloud_proxylb" "test" {
     port       = 80
   }
 }`)
-	warn_sakuracloud_proxylb_unspecified_syslog_host["No syslog server is configured for sakuracloud_proxylb.test"] with input as cfg
+	warn_sakuracloud_proxylb_unspecified_syslog_host["No syslog server is configured for sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/\n"] with input as cfg
 }
 
 test_specified_syslog_host {

--- a/policy/sakuracloud_server.rego
+++ b/policy/sakuracloud_server.rego
@@ -10,5 +10,9 @@ deny_sakuracloud_server_pw_auth_enabled_with_password[msg] {
 	has_field(server.disk_edit_parameter, "password")
 	server.disk_edit_parameter.disable_pw_auth == false
 
-	msg := sprintf("Password authentication is enabled with a password set on sakuracloud_server.%s", [name])
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/"
+	msg := sprintf(
+		"Password authentication is enabled with a password set on sakuracloud_server.%s\nMore Info: %s\n",
+		[name, url],
+	)
 }

--- a/policy/sakuracloud_server_test.rego
+++ b/policy/sakuracloud_server_test.rego
@@ -18,7 +18,7 @@ resource "sakuracloud_server" "test" {
   }
 }`)
 
-	deny_sakuracloud_server_pw_auth_enabled_with_password["Password authentication is enabled with a password set on sakuracloud_server.test"] with input as cfg
+	deny_sakuracloud_server_pw_auth_enabled_with_password["Password authentication is enabled with a password set on sakuracloud_server.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/\n"] with input as cfg
 }
 
 test_disable_pw_auth_with_ssh_key_ids {

--- a/policy/sakuracloud_vpc_router.rego
+++ b/policy/sakuracloud_vpc_router.rego
@@ -10,7 +10,11 @@ deny_sakuracloud_vpc_router_internet_connection_without_firewall[msg] {
 	is_internet_connected(vpc_router)
 	not used_firewall_global_interface(vpc_router)
 
-	msg := sprintf("Internet connection is enabled on sakuracloud_vpc_router.%s, but no firewall is configured on the global interface", [name])
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/"
+	msg := sprintf(
+		"Internet connection is enabled on sakuracloud_vpc_router.%s, but no firewall is configured on the global interface\nMore Info: %s\n",
+		[name, url],
+	)
 }
 
 is_internet_connected(vpc_router) {
@@ -35,5 +39,9 @@ warn_sakuracloud_vpc_router_unspecified_syslog_host[msg] {
 	vpc_router := input.resource.sakuracloud_vpc_router[name]
 	not has_field(vpc_router, "syslog_host")
 
-	msg := sprintf("No syslog server is configured for sakuracloud_vpc_router.%s", [name])
+	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/"
+	msg := sprintf(
+		"No syslog server is configured for sakuracloud_vpc_router.%s\nMore Info: %s\n",
+		[name, url],
+	)
 }

--- a/policy/sakuracloud_vpc_router_test.rego
+++ b/policy/sakuracloud_vpc_router_test.rego
@@ -9,7 +9,7 @@ resource "sakuracloud_vpc_router" "test" {
   internet_connection = true
 }
     `)
-	deny_sakuracloud_vpc_router_internet_connection_without_firewall["Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface"] with input as cfg
+	deny_sakuracloud_vpc_router_internet_connection_without_firewall["Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n"] with input as cfg
 }
 
 test_enable_internet_connection_with_private_interface_firewall {
@@ -46,7 +46,7 @@ resource "sakuracloud_vpc_router" "test" {
   }
 }
     `)
-	deny_sakuracloud_vpc_router_internet_connection_without_firewall["Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface"] with input as cfg
+	deny_sakuracloud_vpc_router_internet_connection_without_firewall["Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n"] with input as cfg
 }
 
 test_enable_internet_connection_with_global_interface_firewall {
@@ -165,7 +165,7 @@ resource "sakuracloud_vpc_router" "test" {
   internet_connection = true
 }
     `)
-	warn_sakuracloud_vpc_router_unspecified_syslog_host["No syslog server is configured for sakuracloud_vpc_router.test"] with input as cfg
+	warn_sakuracloud_vpc_router_unspecified_syslog_host["No syslog server is configured for sakuracloud_vpc_router.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/\n"] with input as cfg
 }
 
 test_specified_syslog_host {


### PR DESCRIPTION
## 概要
ポリシー違反時に詳細情報を確認できるように、メッセージに[ドキュメント](https://docs.usacloud.jp/terraform-policy/)へのURLを追加しました。

## 動作確認
ポリシーに違反するようなterraformのサンプルプロジェクトを作成し実行しました。

```sh
$ conftest test . --ignore=".git/|.terraform/"
WARN - vpc_router.tf - main - No syslog server is configured for sakuracloud_vpc_router.fail_vpc_1
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/

FAIL - vpc_router.tf - main - Internet connection is enabled on sakuracloud_vpc_router.fail_vpc_1, but no firewall is configured on the global interface
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/

FAIL - enhanced_db.tf - main - Source network is not restricted for sakuracloud_enhanced_db.fail_enhanced_db_1 connection
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/

FAIL - lb.tf - main - Port 80 is open on the VIP address of sakuracloud_load_balancer.fail_lb_1
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/

WARN - proxylb.tf - main - No syslog server is configured for sakuracloud_proxylb.fail_proxylb_1
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/

FAIL - proxylb.tf - main - HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.fail_proxylb_1
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/

FAIL - server.tf - main - Password authentication is enabled with a password set on sakuracloud_server.fail_server_1
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/

FAIL - disk.tf - main - Disk encryption is not enabled in sakuracloud_disk.fail_disk_1
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/


120 tests, 112 passed, 2 warnings, 6 failures, 0 exceptions
```
