### PR TITLE
exceptionの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ jobs:
         run: conftest test . --ignore=".git/|.github/|.terraform/" --data="exception.json"
 ```
 
+## Exception
+You can use the Exception feature in Conftest to treat specific rules as exceptions.
+
+In the Conftest execution environment, add a YAML file like the one below. This file should list the names of the rules that you want to treat as exceptions.
+
+```yaml
+exception:
+  rule:
+    - sakuracloud_disk_not_encrypted
+```
+
+Then, use the [--data](https://www.conftest.dev/options/#-data) option with the `conftest test` command to load the above file.
+
+This will cause the listed rules to be counted as exceptions, not failures.
+
+```sh
+$ conftest test disk.tf --ignore=".git/|.github/|.terraform/" --data="exception.yml"
+EXCP - disk.tf - main - data.main.exception[_][_] == "sakuracloud_disk_not_encrypted"
+
+8 tests, 7 passed, 0 warnings, 0 failures, 1 exception
+```
+
 ## Requirements
 [Open Policy Agent](https://www.openpolicyagent.org/) v0.68.0+
 

--- a/policy/sakuracloud_disk.rego
+++ b/policy/sakuracloud_disk.rego
@@ -30,12 +30,3 @@ exception contains rules if {
 	exception.rule[_] == v.rule
 	rules := [v.rule]
 }
-
-exception contains rules if {
-	v := data.main.violation_sakuracloud_disk_not_encrypted[_]
-
-	some name
-	input.resource[v.resource][name]
-	name == exception.resource[v.resource][_]
-	rules := [v.rule]
-}

--- a/policy/sakuracloud_disk.rego
+++ b/policy/sakuracloud_disk.rego
@@ -2,15 +2,40 @@ package main
 
 import data.exception
 import data.helpers.has_field
+import rego.v1
 
-deny_sakuracloud_disk_not_encrypted[msg] {
+violation_sakuracloud_disk_not_encrypted contains decision if {
+	resource := "sakuracloud_disk"
+	rule := "sakuracloud_disk_not_encrypted"
+
 	some name
 	disk := input.resource.sakuracloud_disk[name]
 	not disk.encryption_algorithm == "aes256_xts"
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/"
-	msg := sprintf(
-		"Disk encryption is not enabled in sakuracloud_disk.%s\nMore Info: %s\n",
-		[name, url],
-	)
+	decision := {
+		"msg": sprintf(
+			"Disk encryption is not enabled in sakuracloud_disk.%s\nMore Info: %s\n",
+			[name, url],
+		),
+		"resource": resource,
+		"rule": rule,
+	}
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_disk_not_encrypted[_]
+
+	input.resource[v.resource]
+	exception.rule[_] == v.rule
+	rules := [v.rule]
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_disk_not_encrypted[_]
+
+	some name
+	input.resource[v.resource][name]
+	name == exception.resource[v.resource][_]
+	rules := [v.rule]
 }

--- a/policy/sakuracloud_disk.rego
+++ b/policy/sakuracloud_disk.rego
@@ -9,14 +9,14 @@ violation_sakuracloud_disk_not_encrypted contains decision if {
 	rule := "sakuracloud_disk_not_encrypted"
 
 	some name
-	disk := input.resource.sakuracloud_disk[name]
+	disk := input.resource[resource][name]
 	not disk.encryption_algorithm == "aes256_xts"
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/"
 	decision := {
 		"msg": sprintf(
-			"Disk encryption is not enabled in sakuracloud_disk.%s\nMore Info: %s\n",
-			[name, url],
+			"%s\nDisk encryption is not enabled in %s.%s\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,

--- a/policy/sakuracloud_disk_test.rego
+++ b/policy/sakuracloud_disk_test.rego
@@ -12,7 +12,7 @@ resource "sakuracloud_disk" "test" {
   source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
 }`)
 	violation_sakuracloud_disk_not_encrypted[{
-		"msg": "Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n",
+		"msg": "sakuracloud_disk_not_encrypted\nDisk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n",
 		"resource": "sakuracloud_disk",
 		"rule": "sakuracloud_disk_not_encrypted",
 	}] with input as cfg
@@ -29,7 +29,7 @@ resource "sakuracloud_disk" "test" {
   encryption_algorithm = "none"
 }`)
 	violation_sakuracloud_disk_not_encrypted[{
-		"msg": "Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n",
+		"msg": "sakuracloud_disk_not_encrypted\nDisk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n",
 		"resource": "sakuracloud_disk",
 		"rule": "sakuracloud_disk_not_encrypted",
 	}] with input as cfg

--- a/policy/sakuracloud_disk_test.rego
+++ b/policy/sakuracloud_disk_test.rego
@@ -11,7 +11,11 @@ resource "sakuracloud_disk" "test" {
   connector            = "virtio"
   source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
 }`)
-	deny_sakuracloud_disk_not_encrypted["Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n"] with input as cfg
+	violation_sakuracloud_disk_not_encrypted[{
+		"msg": "Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n",
+		"resource": "sakuracloud_disk",
+		"rule": "sakuracloud_disk_not_encrypted",
+	}] with input as cfg
 }
 
 test_specified_encryption_algorithm_none {
@@ -24,7 +28,11 @@ resource "sakuracloud_disk" "test" {
   source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
   encryption_algorithm = "none"
 }`)
-	deny_sakuracloud_disk_not_encrypted["Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n"] with input as cfg
+	violation_sakuracloud_disk_not_encrypted[{
+		"msg": "Disk encryption is not enabled in sakuracloud_disk.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/\n",
+		"resource": "sakuracloud_disk",
+		"rule": "sakuracloud_disk_not_encrypted",
+	}] with input as cfg
 }
 
 test_specified_encryption_algorithm_aes256_xts {
@@ -37,5 +45,5 @@ resource "sakuracloud_disk" "test" {
   source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
   encryption_algorithm = "aes256_xts"
 }`)
-	no_violations(deny_sakuracloud_disk_not_encrypted) with input as cfg
+	no_violations(violation_sakuracloud_disk_not_encrypted) with input as cfg
 }

--- a/policy/sakuracloud_enhanced_db.rego
+++ b/policy/sakuracloud_enhanced_db.rego
@@ -9,15 +9,15 @@ violation_sakuracloud_enhanced_db_unrestricted_source_networks contains decision
 	rule := "sakuracloud_enhanced_db_unrestricted_source_networks"
 
 	some name
-	enhanced_db := input.resource.sakuracloud_enhanced_db[name]
+	enhanced_db := input.resource[resource][name]
 
 	not has_field(enhanced_db, "allowed_networks")
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/"
 	decision := {
 		"msg": sprintf(
-			"Source network is not restricted for sakuracloud_enhanced_db.%s connection\nMore Info: %s\n",
-			[name, url],
+			"%s\nSource network is not restricted for %s.%s connection\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,

--- a/policy/sakuracloud_enhanced_db.rego
+++ b/policy/sakuracloud_enhanced_db.rego
@@ -2,16 +2,41 @@ package main
 
 import data.exception
 import data.helpers.has_field
+import rego.v1
 
-deny_sakuracloud_enhanced_db_unrestricted_source_networks[msg] {
+violation_sakuracloud_enhanced_db_unrestricted_source_networks contains decision if {
+	resource := "sakuracloud_enhanced_db"
+	rule := "sakuracloud_enhanced_db_unrestricted_source_networks"
+
 	some name
 	enhanced_db := input.resource.sakuracloud_enhanced_db[name]
 
 	not has_field(enhanced_db, "allowed_networks")
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/"
-	msg := sprintf(
-		"Source network is not restricted for sakuracloud_enhanced_db.%s connection\nMore Info: %s\n",
-		[name, url],
-	)
+	decision := {
+		"msg": sprintf(
+			"Source network is not restricted for sakuracloud_enhanced_db.%s connection\nMore Info: %s\n",
+			[name, url],
+		),
+		"resource": resource,
+		"rule": rule,
+	}
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_enhanced_db_unrestricted_source_networks[_]
+
+	input.resource[v.resource]
+	exception.rule[_] == v.rule
+	rules := [v.rule]
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_enhanced_db_unrestricted_source_networks[_]
+
+	some name
+	input.resource[v.resource][name]
+	name == exception.resource[v.resource][_]
+	rules := [v.rule]
 }

--- a/policy/sakuracloud_enhanced_db.rego
+++ b/policy/sakuracloud_enhanced_db.rego
@@ -31,12 +31,3 @@ exception contains rules if {
 	exception.rule[_] == v.rule
 	rules := [v.rule]
 }
-
-exception contains rules if {
-	v := data.main.violation_sakuracloud_enhanced_db_unrestricted_source_networks[_]
-
-	some name
-	input.resource[v.resource][name]
-	name == exception.resource[v.resource][_]
-	rules := [v.rule]
-}

--- a/policy/sakuracloud_enhanced_db_test.rego
+++ b/policy/sakuracloud_enhanced_db_test.rego
@@ -14,7 +14,7 @@ resource "sakuracloud_enhanced_db" "test" {
 }`)
 
 	violation_sakuracloud_enhanced_db_unrestricted_source_networks[{
-		"msg": "Source network is not restricted for sakuracloud_enhanced_db.test connection\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/\n",
+		"msg": "sakuracloud_enhanced_db_unrestricted_source_networks\nSource network is not restricted for sakuracloud_enhanced_db.test connection\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/\n",
 		"resource": "sakuracloud_enhanced_db",
 		"rule": "sakuracloud_enhanced_db_unrestricted_source_networks",
 	}] with input as cfg

--- a/policy/sakuracloud_enhanced_db_test.rego
+++ b/policy/sakuracloud_enhanced_db_test.rego
@@ -13,7 +13,11 @@ resource "sakuracloud_enhanced_db" "test" {
   region        = "is1"
 }`)
 
-	deny_sakuracloud_enhanced_db_unrestricted_source_networks["Source network is not restricted for sakuracloud_enhanced_db.test connection\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/\n"] with input as cfg
+	violation_sakuracloud_enhanced_db_unrestricted_source_networks[{
+		"msg": "Source network is not restricted for sakuracloud_enhanced_db.test connection\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_enhanced_db/unrestricted_source_networks/\n",
+		"resource": "sakuracloud_enhanced_db",
+		"rule": "sakuracloud_enhanced_db_unrestricted_source_networks",
+	}] with input as cfg
 }
 
 test_specified_allowed_networks {
@@ -31,5 +35,5 @@ resource "sakuracloud_enhanced_db" "test" {
   ]
 }`)
 
-	no_violations(deny_sakuracloud_enhanced_db_unrestricted_source_networks) with input as cfg
+	no_violations(violation_sakuracloud_enhanced_db_unrestricted_source_networks) with input as cfg
 }

--- a/policy/sakuracloud_load_balancer.rego
+++ b/policy/sakuracloud_load_balancer.rego
@@ -15,8 +15,8 @@ violation_sakuracloud_load_balancer_http_not_enabled contains decision if {
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/"
 	decision := {
 		"msg": sprintf(
-			"Port 80 is open on the VIP address of %s.%s\nMore Info: %s\n",
-			[resource, name, url],
+			"%s\nPort 80 is open on the VIP address of %s.%s\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,

--- a/policy/sakuracloud_load_balancer.rego
+++ b/policy/sakuracloud_load_balancer.rego
@@ -2,15 +2,40 @@ package main
 
 import data.exception
 import data.helpers.has_field
+import rego.v1
 
-deny_sakuracloud_load_balancer_http_not_enabled[msg] {
+violation_sakuracloud_load_balancer_http_not_enabled contains decision if {
+	resource := "sakuracloud_load_balancer"
+	rule := "sakuracloud_load_balancer_http_not_enabled"
+
 	some name
-	load_balancer := input.resource.sakuracloud_load_balancer[name]
+	load_balancer := input.resource[resource][name]
 	load_balancer.vip.port == 80
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/"
-	msg := sprintf(
-		"Port 80 is open on the VIP address of sakuracloud_load_balancer.%s\nMore Info: %s\n",
-		[name, url],
-	)
+	decision := {
+		"msg": sprintf(
+			"Port 80 is open on the VIP address of %s.%s\nMore Info: %s\n",
+			[resource, name, url],
+		),
+		"resource": resource,
+		"rule": rule,
+	}
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_load_balancer_http_not_enabled[_]
+
+	input.resource[v.resource]
+	exception.rule[_] == v.rule
+	rules := [v.rule]
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_load_balancer_http_not_enabled[_]
+
+	some name
+	input.resource[v.resource][name]
+	name == exception.resource[v.resource][_]
+	rules := [v.rule]
 }

--- a/policy/sakuracloud_load_balancer.rego
+++ b/policy/sakuracloud_load_balancer.rego
@@ -30,12 +30,3 @@ exception contains rules if {
 	exception.rule[_] == v.rule
 	rules := [v.rule]
 }
-
-exception contains rules if {
-	v := data.main.violation_sakuracloud_load_balancer_http_not_enabled[_]
-
-	some name
-	input.resource[v.resource][name]
-	name == exception.resource[v.resource][_]
-	rules := [v.rule]
-}

--- a/policy/sakuracloud_load_balancer_test.rego
+++ b/policy/sakuracloud_load_balancer_test.rego
@@ -33,8 +33,11 @@ resource "sakuracloud_load_balancer" "test" {
     }
   }
 }`)
-
-	deny_sakuracloud_load_balancer_http_not_enabled["Port 80 is open on the VIP address of sakuracloud_load_balancer.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/\n"] with input as cfg
+	violation_sakuracloud_load_balancer_http_not_enabled[{
+		"msg": "Port 80 is open on the VIP address of sakuracloud_load_balancer.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/\n",
+		"resource": "sakuracloud_load_balancer",
+		"rule": "sakuracloud_load_balancer_http_not_enabled",
+	}] with input as cfg
 }
 
 test_enable_https_port {
@@ -68,8 +71,7 @@ resource "sakuracloud_load_balancer" "test" {
     }
   }
 }`)
-
-	no_violations(deny_sakuracloud_load_balancer_http_not_enabled) with input as cfg
+	no_violations(violation_sakuracloud_load_balancer_http_not_enabled) with input as cfg
 }
 
 test_not_specified_vip {
@@ -85,6 +87,5 @@ resource "sakuracloud_load_balancer" "test" {
     gateway      = "192.168.0.1"
   }
 }`)
-
-	no_violations(deny_sakuracloud_load_balancer_http_not_enabled) with input as cfg
+	no_violations(violation_sakuracloud_load_balancer_http_not_enabled) with input as cfg
 }

--- a/policy/sakuracloud_load_balancer_test.rego
+++ b/policy/sakuracloud_load_balancer_test.rego
@@ -34,7 +34,7 @@ resource "sakuracloud_load_balancer" "test" {
   }
 }`)
 	violation_sakuracloud_load_balancer_http_not_enabled[{
-		"msg": "Port 80 is open on the VIP address of sakuracloud_load_balancer.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/\n",
+		"msg": "sakuracloud_load_balancer_http_not_enabled\nPort 80 is open on the VIP address of sakuracloud_load_balancer.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_load_balancer/http_not_enabled/\n",
 		"resource": "sakuracloud_load_balancer",
 		"rule": "sakuracloud_load_balancer_http_not_enabled",
 	}] with input as cfg

--- a/policy/sakuracloud_proxylb.rego
+++ b/policy/sakuracloud_proxylb.rego
@@ -9,14 +9,14 @@ violation_sakuracloud_proxylb_no_https_redirect contains decision if {
 	rule := "sakuracloud_proxylb_no_https_redirect"
 
 	some name
-	proxylb := input.resource.sakuracloud_proxylb[name]
+	proxylb := input.resource[resource][name]
 	not redirect_https(proxylb)
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/"
 	decision := {
 		"msg": sprintf(
-			"HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.%s\nMore Info: %s\n",
-			[name, url],
+			"%s\nHTTP to HTTPS redirect is not enabled on %s.%s\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,
@@ -57,14 +57,14 @@ warn_sakuracloud_proxylb_unspecified_syslog_host contains decision if {
 	rule := "sakuracloud_proxylb_unspecified_syslog_host"
 
 	some name
-	proxylb := input.resource.sakuracloud_proxylb[name]
+	proxylb := input.resource[resource][name]
 	not has_field(proxylb, "syslog")
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/"
 
 	decision := {
 		"msg": sprintf(
-			"No syslog server is configured for sakuracloud_proxylb.%s\nMore Info: %s\n",
-			[name, url],
+			"%s\nNo syslog server is configured for %s.%s\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,

--- a/policy/sakuracloud_proxylb.rego
+++ b/policy/sakuracloud_proxylb.rego
@@ -43,15 +43,6 @@ exception contains rules if {
 	rules := [v.rule]
 }
 
-exception contains rules if {
-	v := data.main.violation_sakuracloud_proxylb_no_https_redirect[_]
-
-	some name
-	input.resource[v.resource][name]
-	name == exception.resource[v.resource][_]
-	rules := [v.rule]
-}
-
 warn_sakuracloud_proxylb_unspecified_syslog_host contains decision if {
 	resource := "sakuracloud_proxylb"
 	rule := "sakuracloud_proxylb_unspecified_syslog_host"
@@ -76,14 +67,5 @@ exception contains rules if {
 
 	input.resource[v.resource]
 	exception.rule[_] == v.rule
-	rules := [v.rule]
-}
-
-exception contains rules if {
-	v := data.main.warn_sakuracloud_proxylb_unspecified_syslog_host[_]
-
-	some name
-	input.resource[v.resource][name]
-	name == exception.resource[v.resource][_]
 	rules := [v.rule]
 }

--- a/policy/sakuracloud_proxylb_test.rego
+++ b/policy/sakuracloud_proxylb_test.rego
@@ -21,7 +21,7 @@ resource "sakuracloud_proxylb" "test" {
   }
 }`)
 	violation_sakuracloud_proxylb_no_https_redirect[{
-		"msg": "HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n",
+		"msg": "sakuracloud_proxylb_no_https_redirect\nHTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n",
 		"resource": "sakuracloud_proxylb",
 		"rule": "sakuracloud_proxylb_no_https_redirect",
 	}] with input as cfg
@@ -47,7 +47,7 @@ resource "sakuracloud_proxylb" "test" {
   }
 }`)
 	violation_sakuracloud_proxylb_no_https_redirect[{
-		"msg": "HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n",
+		"msg": "sakuracloud_proxylb_no_https_redirect\nHTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n",
 		"resource": "sakuracloud_proxylb",
 		"rule": "sakuracloud_proxylb_no_https_redirect",
 	}] with input as cfg
@@ -118,7 +118,7 @@ resource "sakuracloud_proxylb" "test" {
   }
 }`)
 	warn_sakuracloud_proxylb_unspecified_syslog_host[{
-		"msg": "No syslog server is configured for sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/\n",
+		"msg": "sakuracloud_proxylb_unspecified_syslog_host\nNo syslog server is configured for sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/\n",
 		"resource": "sakuracloud_proxylb",
 		"rule": "sakuracloud_proxylb_unspecified_syslog_host",
 	}] with input as cfg

--- a/policy/sakuracloud_proxylb_test.rego
+++ b/policy/sakuracloud_proxylb_test.rego
@@ -20,7 +20,11 @@ resource "sakuracloud_proxylb" "test" {
     port       = 80
   }
 }`)
-	deny_sakuracloud_proxylb_no_https_redirect["HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n"] with input as cfg
+	violation_sakuracloud_proxylb_no_https_redirect[{
+		"msg": "HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n",
+		"resource": "sakuracloud_proxylb",
+		"rule": "sakuracloud_proxylb_no_https_redirect",
+	}] with input as cfg
 }
 
 test_disable_redirect_to_https {
@@ -42,7 +46,11 @@ resource "sakuracloud_proxylb" "test" {
     redirect_to_https = false
   }
 }`)
-	deny_sakuracloud_proxylb_no_https_redirect["HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n"] with input as cfg
+	violation_sakuracloud_proxylb_no_https_redirect[{
+		"msg": "HTTP to HTTPS redirect is not enabled on sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/no_https_redirect/\n",
+		"resource": "sakuracloud_proxylb",
+		"rule": "sakuracloud_proxylb_no_https_redirect",
+	}] with input as cfg
 }
 
 test_redirect_to_https {
@@ -68,7 +76,7 @@ resource "sakuracloud_proxylb" "test" {
     port       = 443
   }
 }`)
-	no_violations(deny_sakuracloud_proxylb_no_https_redirect) with input as cfg
+	no_violations(violation_sakuracloud_proxylb_no_https_redirect) with input as cfg
 }
 
 test_redirect_to_https_not_specified_https_bind_port {
@@ -89,7 +97,7 @@ resource "sakuracloud_proxylb" "test" {
     redirect_to_https = true
   }
 }`)
-	no_violations(deny_sakuracloud_proxylb_no_https_redirect) with input as cfg
+	no_violations(violation_sakuracloud_proxylb_no_https_redirect) with input as cfg
 }
 
 test_unspecified_syslog_host {
@@ -109,7 +117,11 @@ resource "sakuracloud_proxylb" "test" {
     port       = 80
   }
 }`)
-	warn_sakuracloud_proxylb_unspecified_syslog_host["No syslog server is configured for sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/\n"] with input as cfg
+	warn_sakuracloud_proxylb_unspecified_syslog_host[{
+		"msg": "No syslog server is configured for sakuracloud_proxylb.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_proxylb/unspecified_syslog_host/\n",
+		"resource": "sakuracloud_proxylb",
+		"rule": "sakuracloud_proxylb_unspecified_syslog_host",
+	}] with input as cfg
 }
 
 test_specified_syslog_host {

--- a/policy/sakuracloud_server.rego
+++ b/policy/sakuracloud_server.rego
@@ -2,8 +2,12 @@ package main
 
 import data.exception
 import data.helpers.has_field
+import rego.v1
 
-deny_sakuracloud_server_pw_auth_enabled_with_password[msg] {
+violation_sakuracloud_server_pw_auth_enabled_with_password contains decision if {
+	resource := "sakuracloud_server"
+	rule := "sakuracloud_server_pw_auth_enabled_with_password"
+
 	some name
 	server := input.resource.sakuracloud_server[name]
 
@@ -11,8 +15,29 @@ deny_sakuracloud_server_pw_auth_enabled_with_password[msg] {
 	server.disk_edit_parameter.disable_pw_auth == false
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/"
-	msg := sprintf(
-		"Password authentication is enabled with a password set on sakuracloud_server.%s\nMore Info: %s\n",
-		[name, url],
-	)
+	decision := {
+		"msg": sprintf(
+			"Password authentication is enabled with a password set on sakuracloud_server.%s\nMore Info: %s\n",
+			[name, url],
+		),
+		"resource": resource,
+		"rule": rule,
+	}
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_server_pw_auth_enabled_with_password[_]
+
+	input.resource[v.resource]
+	exception.rule[_] == v.rule
+	rules := [v.rule]
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_server_pw_auth_enabled_with_password[_]
+
+	some name
+	input.resource[v.resource][name]
+	name == exception.resource[v.resource][_]
+	rules := [v.rule]
 }

--- a/policy/sakuracloud_server.rego
+++ b/policy/sakuracloud_server.rego
@@ -32,12 +32,3 @@ exception contains rules if {
 	exception.rule[_] == v.rule
 	rules := [v.rule]
 }
-
-exception contains rules if {
-	v := data.main.violation_sakuracloud_server_pw_auth_enabled_with_password[_]
-
-	some name
-	input.resource[v.resource][name]
-	name == exception.resource[v.resource][_]
-	rules := [v.rule]
-}

--- a/policy/sakuracloud_server.rego
+++ b/policy/sakuracloud_server.rego
@@ -9,7 +9,7 @@ violation_sakuracloud_server_pw_auth_enabled_with_password contains decision if 
 	rule := "sakuracloud_server_pw_auth_enabled_with_password"
 
 	some name
-	server := input.resource.sakuracloud_server[name]
+	server := input.resource[resource][name]
 
 	has_field(server.disk_edit_parameter, "password")
 	server.disk_edit_parameter.disable_pw_auth == false
@@ -17,8 +17,8 @@ violation_sakuracloud_server_pw_auth_enabled_with_password contains decision if 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/"
 	decision := {
 		"msg": sprintf(
-			"Password authentication is enabled with a password set on sakuracloud_server.%s\nMore Info: %s\n",
-			[name, url],
+			"%s\nPassword authentication is enabled with a password set on %s.%s\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,

--- a/policy/sakuracloud_server_test.rego
+++ b/policy/sakuracloud_server_test.rego
@@ -18,7 +18,11 @@ resource "sakuracloud_server" "test" {
   }
 }`)
 
-	deny_sakuracloud_server_pw_auth_enabled_with_password["Password authentication is enabled with a password set on sakuracloud_server.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/\n"] with input as cfg
+	violation_sakuracloud_server_pw_auth_enabled_with_password[{
+		"msg": "Password authentication is enabled with a password set on sakuracloud_server.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/\n",
+		"resource": "sakuracloud_server",
+		"rule": "sakuracloud_server_pw_auth_enabled_with_password",
+	}] with input as cfg
 }
 
 test_disable_pw_auth_with_ssh_key_ids {
@@ -37,7 +41,7 @@ resource "sakuracloud_server" "test" {
   }
 }`)
 
-	no_violations(deny_sakuracloud_server_pw_auth_enabled_with_password) with input as cfg
+	no_violations(violation_sakuracloud_server_pw_auth_enabled_with_password) with input as cfg
 }
 
 test_disable_pw_auth_with_password_and_ssh_key_ids {
@@ -57,7 +61,7 @@ resource "sakuracloud_server" "test" {
   }
 }`)
 
-	no_violations(deny_sakuracloud_server_pw_auth_enabled_with_password) with input as cfg
+	no_violations(violation_sakuracloud_server_pw_auth_enabled_with_password) with input as cfg
 }
 
 test_not_specified_disk_edit_parameter {
@@ -69,5 +73,5 @@ resource "sakuracloud_server" "test" {
   memory = 1
 }`)
 
-	no_violations(deny_sakuracloud_server_pw_auth_enabled_with_password) with input as cfg
+	no_violations(violation_sakuracloud_server_pw_auth_enabled_with_password) with input as cfg
 }

--- a/policy/sakuracloud_server_test.rego
+++ b/policy/sakuracloud_server_test.rego
@@ -19,7 +19,7 @@ resource "sakuracloud_server" "test" {
 }`)
 
 	violation_sakuracloud_server_pw_auth_enabled_with_password[{
-		"msg": "Password authentication is enabled with a password set on sakuracloud_server.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/\n",
+		"msg": "sakuracloud_server_pw_auth_enabled_with_password\nPassword authentication is enabled with a password set on sakuracloud_server.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_server/pw_auth_enabled_with_password/\n",
 		"resource": "sakuracloud_server",
 		"rule": "sakuracloud_server_pw_auth_enabled_with_password",
 	}] with input as cfg

--- a/policy/sakuracloud_vpc_router.rego
+++ b/policy/sakuracloud_vpc_router.rego
@@ -9,7 +9,7 @@ violation_sakuracloud_vpc_router_internet_connection_without_firewall contains d
 	rule := "sakuracloud_vpc_router_internet_connection_without_firewall"
 
 	some name
-	vpc_router := input.resource.sakuracloud_vpc_router[name]
+	vpc_router := input.resource[resource][name]
 
 	is_internet_connected(vpc_router)
 	not used_firewall_global_interface(vpc_router)
@@ -17,8 +17,8 @@ violation_sakuracloud_vpc_router_internet_connection_without_firewall contains d
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/"
 	decision := {
 		"msg": sprintf(
-			"Internet connection is enabled on sakuracloud_vpc_router.%s, but no firewall is configured on the global interface\nMore Info: %s\n",
-			[name, url],
+			"%s\nInternet connection is enabled on %s.%s, but no firewall is configured on the global interface\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,
@@ -63,16 +63,14 @@ warn_sakuracloud_vpc_router_unspecified_syslog_host contains decision if {
 	rule := "sakuracloud_vpc_router_unspecified_syslog_host"
 
 	some name
-
-	vpc_router := input.resource.sakuracloud_vpc_router[name]
+	vpc_router := input.resource[resource][name]
 	not has_field(vpc_router, "syslog_host")
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/"
-
 	decision := {
 		"msg": sprintf(
-			"No syslog server is configured for sakuracloud_vpc_router.%s\nMore Info: %s\n",
-			[name, url],
+			"%s\nNo syslog server is configured for %s.%s\nMore Info: %s\n",
+			[rule, resource, name, url],
 		),
 		"resource": resource,
 		"rule": rule,

--- a/policy/sakuracloud_vpc_router.rego
+++ b/policy/sakuracloud_vpc_router.rego
@@ -2,8 +2,12 @@ package main
 
 import data.exception
 import data.helpers.has_field
+import rego.v1
 
-deny_sakuracloud_vpc_router_internet_connection_without_firewall[msg] {
+violation_sakuracloud_vpc_router_internet_connection_without_firewall contains decision if {
+	resource := "sakuracloud_vpc_router"
+	rule := "sakuracloud_vpc_router_internet_connection_without_firewall"
+
 	some name
 	vpc_router := input.resource.sakuracloud_vpc_router[name]
 
@@ -11,37 +15,83 @@ deny_sakuracloud_vpc_router_internet_connection_without_firewall[msg] {
 	not used_firewall_global_interface(vpc_router)
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/"
-	msg := sprintf(
-		"Internet connection is enabled on sakuracloud_vpc_router.%s, but no firewall is configured on the global interface\nMore Info: %s\n",
-		[name, url],
-	)
+	decision := {
+		"msg": sprintf(
+			"Internet connection is enabled on sakuracloud_vpc_router.%s, but no firewall is configured on the global interface\nMore Info: %s\n",
+			[name, url],
+		),
+		"resource": resource,
+		"rule": rule,
+	}
 }
 
-is_internet_connected(vpc_router) {
+is_internet_connected(vpc_router) if {
 	not has_field(vpc_router, "internet_connection")
 }
 
-is_internet_connected(vpc_router) {
+is_internet_connected(vpc_router) if {
 	vpc_router.internet_connection == true
 }
 
-used_firewall_global_interface(vpc_router) {
+used_firewall_global_interface(vpc_router) if {
 	vpc_router.firewall.interface_index == 0
 }
 
-used_firewall_global_interface(vpc_router) {
+used_firewall_global_interface(vpc_router) if {
 	vpc_router.firewall[_].interface_index == 0
 }
 
-warn_sakuracloud_vpc_router_unspecified_syslog_host[msg] {
+exception contains rules if {
+	v := data.main.violation_sakuracloud_vpc_router_internet_connection_without_firewall[_]
+
+	input.resource[v.resource]
+	exception.rule[_] == v.rule
+	rules := [v.rule]
+}
+
+exception contains rules if {
+	v := data.main.violation_sakuracloud_vpc_router_internet_connection_without_firewall[_]
+
+	some name
+	input.resource[v.resource][name]
+	name == exception.resource[v.resource][_]
+	rules := [v.rule]
+}
+
+warn_sakuracloud_vpc_router_unspecified_syslog_host contains decision if {
+	resource := "sakuracloud_vpc_router"
+	rule := "sakuracloud_vpc_router_unspecified_syslog_host"
+
 	some name
 
 	vpc_router := input.resource.sakuracloud_vpc_router[name]
 	not has_field(vpc_router, "syslog_host")
 
 	url := "https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/"
-	msg := sprintf(
-		"No syslog server is configured for sakuracloud_vpc_router.%s\nMore Info: %s\n",
-		[name, url],
-	)
+
+	decision := {
+		"msg": sprintf(
+			"No syslog server is configured for sakuracloud_vpc_router.%s\nMore Info: %s\n",
+			[name, url],
+		),
+		"resource": resource,
+		"rule": rule,
+	}
+}
+
+exception contains rules if {
+	v := data.main.warn_sakuracloud_vpc_router_unspecified_syslog_host[_]
+
+	input.resource[v.resource]
+	exception.rule[_] == v.rule
+	rules := [v.rule]
+}
+
+exception contains rules if {
+	v := data.main.warn_sakuracloud_vpc_router_unspecified_syslog_host[_]
+
+	some name
+	input.resource[v.resource][name]
+	name == exception.resource[v.resource][_]
+	rules := [v.rule]
 }

--- a/policy/sakuracloud_vpc_router.rego
+++ b/policy/sakuracloud_vpc_router.rego
@@ -84,12 +84,3 @@ exception contains rules if {
 	exception.rule[_] == v.rule
 	rules := [v.rule]
 }
-
-exception contains rules if {
-	v := data.main.warn_sakuracloud_vpc_router_unspecified_syslog_host[_]
-
-	some name
-	input.resource[v.resource][name]
-	name == exception.resource[v.resource][_]
-	rules := [v.rule]
-}

--- a/policy/sakuracloud_vpc_router_test.rego
+++ b/policy/sakuracloud_vpc_router_test.rego
@@ -9,7 +9,7 @@ resource "sakuracloud_vpc_router" "test" {
   internet_connection = true
 }`)
 	violation_sakuracloud_vpc_router_internet_connection_without_firewall[{
-		"msg": "Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n",
+		"msg": "sakuracloud_vpc_router_internet_connection_without_firewall\nInternet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n",
 		"resource": "sakuracloud_vpc_router",
 		"rule": "sakuracloud_vpc_router_internet_connection_without_firewall",
 	}] with input as cfg
@@ -49,7 +49,7 @@ resource "sakuracloud_vpc_router" "test" {
   }
 }`)
 	violation_sakuracloud_vpc_router_internet_connection_without_firewall[{
-		"msg": "Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n",
+		"msg": "sakuracloud_vpc_router_internet_connection_without_firewall\nInternet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n",
 		"resource": "sakuracloud_vpc_router",
 		"rule": "sakuracloud_vpc_router_internet_connection_without_firewall",
 	}] with input as cfg
@@ -170,7 +170,7 @@ resource "sakuracloud_vpc_router" "test" {
 }
     `)
 	warn_sakuracloud_vpc_router_unspecified_syslog_host[{
-		"msg": "No syslog server is configured for sakuracloud_vpc_router.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/\n",
+		"msg": "sakuracloud_vpc_router_unspecified_syslog_host\nNo syslog server is configured for sakuracloud_vpc_router.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/\n",
 		"resource": "sakuracloud_vpc_router",
 		"rule": "sakuracloud_vpc_router_unspecified_syslog_host",
 	}] with input as cfg

--- a/policy/sakuracloud_vpc_router_test.rego
+++ b/policy/sakuracloud_vpc_router_test.rego
@@ -7,9 +7,12 @@ test_enable_internet_connection {
 resource "sakuracloud_vpc_router" "test" {
   name                = "test"
   internet_connection = true
-}
-    `)
-	deny_sakuracloud_vpc_router_internet_connection_without_firewall["Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n"] with input as cfg
+}`)
+	violation_sakuracloud_vpc_router_internet_connection_without_firewall[{
+		"msg": "Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n",
+		"resource": "sakuracloud_vpc_router",
+		"rule": "sakuracloud_vpc_router_internet_connection_without_firewall",
+	}] with input as cfg
 }
 
 test_enable_internet_connection_with_private_interface_firewall {
@@ -44,9 +47,12 @@ resource "sakuracloud_vpc_router" "test" {
       description         = "desc"
     }
   }
-}
-    `)
-	deny_sakuracloud_vpc_router_internet_connection_without_firewall["Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n"] with input as cfg
+}`)
+	violation_sakuracloud_vpc_router_internet_connection_without_firewall[{
+		"msg": "Internet connection is enabled on sakuracloud_vpc_router.test, but no firewall is configured on the global interface\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/internet_connection_without_firewall/\n",
+		"resource": "sakuracloud_vpc_router",
+		"rule": "sakuracloud_vpc_router_internet_connection_without_firewall",
+	}] with input as cfg
 }
 
 test_enable_internet_connection_with_global_interface_firewall {
@@ -80,9 +86,8 @@ resource "sakuracloud_vpc_router" "test" {
       description         = "desc"
     }
   }
-}
-    `)
-	no_violations(deny_sakuracloud_vpc_router_internet_connection_without_firewall) with input as cfg
+}`)
+	no_violations(violation_sakuracloud_vpc_router_internet_connection_without_firewall) with input as cfg
 }
 
 test_enable_internet_connection_with_multi_interface_firewall {
@@ -143,9 +148,8 @@ resource "sakuracloud_vpc_router" "test" {
       description         = "desc"
     }
   }
-}
-    `)
-	no_violations(deny_sakuracloud_vpc_router_internet_connection_without_firewall) with input as cfg
+}`)
+	no_violations(violation_sakuracloud_vpc_router_internet_connection_without_firewall) with input as cfg
 }
 
 test_disable_internet_connection {
@@ -155,7 +159,7 @@ resource "sakuracloud_vpc_router" "test" {
   internet_connection = false
 }
     `)
-	no_violations(deny_sakuracloud_vpc_router_internet_connection_without_firewall) with input as cfg
+	no_violations(violation_sakuracloud_vpc_router_internet_connection_without_firewall) with input as cfg
 }
 
 test_unspecified_syslog_host {
@@ -165,7 +169,11 @@ resource "sakuracloud_vpc_router" "test" {
   internet_connection = true
 }
     `)
-	warn_sakuracloud_vpc_router_unspecified_syslog_host["No syslog server is configured for sakuracloud_vpc_router.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/\n"] with input as cfg
+	warn_sakuracloud_vpc_router_unspecified_syslog_host[{
+		"msg": "No syslog server is configured for sakuracloud_vpc_router.test\nMore Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_vpc_router/unspecified_syslog_host/\n",
+		"resource": "sakuracloud_vpc_router",
+		"rule": "sakuracloud_vpc_router_unspecified_syslog_host",
+	}] with input as cfg
 }
 
 test_specified_syslog_host {
@@ -174,7 +182,6 @@ resource "sakuracloud_vpc_router" "test" {
   name                = "test"
   internet_connection = true
   syslog_host         = "192.168.0.1"
-}
-    `)
+}`)
 	no_violations(warn_sakuracloud_vpc_router_unspecified_syslog_host) with input as cfg
 }


### PR DESCRIPTION
## 概要
特定のルールを例外扱いできるようにして、何かしらの理由でルールを無視できるようにします。

## 設計
利用者は実行時にConftestの `conftest test` コマンドの `--data` optionを利用します。
ref. https://www.conftest.dev/options/#-data

data optionには以下のような例外扱いするルールを列挙したyamlファイルを指定します。

```yaml
exception:
  rule:
    - sakuracloud_disk_not_encrypted
    - sakuracloud_vpc_router_unspecified_syslog_host
```

内部的には上記のyamlファイルで指定されたルールがexceptionのrulesに適用され、exception扱いとなります
https://www.conftest.dev/exceptions/

```sh
$ conftest test disk.tf --ignore=".git/|.terraform/|.github/" --data="exception.yml"
EXCP - disk.tf - main - data.main.exception[_][_] == "sakuracloud_disk_not_encrypted"

8 tests, 7 passed, 0 warnings, 0 failures, 1 exception
```

## 動作確認

- テスト用のterraformコードを用意
```terraform
data "sakuracloud_archive" "ubuntu2204" {
  os_type = "ubuntu2204"
}

resource "sakuracloud_disk" "bad_disk" {
  name                 = "bad_disk"
  size                 = 20
  plan                 = "ssd"
  connector            = "virtio"
  source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
  encryption_algorithm = "none"
}

resource "sakuracloud_disk" "good_disk" {
  name                 = "good_disk"
  size                 = 20
  plan                 = "ssd"
  connector            = "virtio"
  source_archive_id    = data.sakuracloud_archive.ubuntu2204.id
  encryption_algorithm = "aes256_xts"
}
```

- `exception.yml` を用意

```yaml
exception:
  rule:
    - sakuracloud_disk_not_encrypted
```

- `exception.yml` を使わない場合、failすることを確認

```sh
$ conftest test disk.tf --ignore=".git/|.terraform/|.github/" 
FAIL - disk.tf - main - sakuracloud_disk_not_encrypted
Disk encryption is not enabled in sakuracloud_disk.fail_disk_1
More Info: https://docs.usacloud.jp/terraform-policy/rules/sakuracloud_disk/not_encrypted/


8 tests, 7 passed, 0 warnings, 1 failure, 0 exceptions
```

- `exception.yml` を使った場合、exceptionになることを確認

```sh
$ conftest test disk.tf --ignore=".git/|.terraform/|.github/" --data="exception.yml"
EXCP - disk.tf - main - data.main.exception[_][_] == "sakuracloud_disk_not_encrypted"

8 tests, 7 passed, 0 warnings, 0 failures, 1 exception
``` 